### PR TITLE
Remove deprecated email config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Terraform Provider
 Requirements
 ------------
 
--	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.12+ (to build the provider plugin)
+- [Terraform](https://www.terraform.io/downloads.html) 0.10.x
+- [Go](https://golang.org/doc/install) 1.12+ (to build the provider plugin)
 
 Building The Provider
 ---------------------
@@ -32,7 +32,8 @@ $ make build
 
 Using the provider
 ----------------------
-## Fill in for each provider
+
+See the [DNSimple Provider documentation](https://www.terraform.io/docs/providers/dnsimple/index.html) to get started using the DNSimple provider.
 
 Developing the Provider
 ---------------------------

--- a/dnsimple/provider.go
+++ b/dnsimple/provider.go
@@ -1,8 +1,6 @@
 package dnsimple
 
 import (
-	"errors"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -11,13 +9,6 @@ import (
 func Provider() terraform.ResourceProvider {
 	p := &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"email": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("DNSIMPLE_EMAIL", ""),
-				Description: "The DNSimple account email address.",
-			},
-
 			"token": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -51,18 +42,6 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData, terraformVersion string) (interface{}, error) {
-	// DNSimple API v1 requires email+token to authenticate.
-	// DNSimple API v2 requires only an OAuth token and in this particular case
-	// the reference of the account for API operations (to avoid fetching it in real time).
-	//
-	// v2 is not backward compatible with v1, therefore return an error in case email is set,
-	// to inform the user to upgrade to v2. Also, v1 token is not the same of v2.
-	if email := d.Get("email").(string); email != "" {
-		return nil, errors.New(
-			"DNSimple API v2 requires an account identifier and the new OAuth token. " +
-				"Please upgrade your configuration.")
-	}
-
 	config := Config{
 		Token:            d.Get("token").(string),
 		Account:          d.Get("account").(string),

--- a/dnsimple/provider_test.go
+++ b/dnsimple/provider_test.go
@@ -29,10 +29,6 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("DNSIMPLE_EMAIL"); v != "" {
-		t.Fatal("DNSIMPLE_EMAIL is no longer required for DNSimple API v2")
-	}
-
 	if v := os.Getenv("DNSIMPLE_TOKEN"); v == "" {
 		t.Fatal("DNSIMPLE_TOKEN must be set for acceptance tests")
 	}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -2,8 +2,7 @@
 layout: "dnsimple"
 page_title: "Provider: DNSimple"
 sidebar_current: "docs-dnsimple-index"
-description: |-
-  The DNSimple provider is used to interact with the resources supported by DNSimple. The provider needs to be configured with the proper credentials before it can be used.
+description: "The DNSimple provider is used to interact with the resources supported by DNSimple."
 ---
 
 # DNSimple Provider


### PR DESCRIPTION
API v1 is gone. The deprecation has been in place for over 3 years. I'm taking the opportunity of the switch to the plugin SDK to cleanup the code.