### PR TITLE
Adjust UserAgent to use Terraform SDK UserAgent

### DIFF
--- a/dnsimple/config.go
+++ b/dnsimple/config.go
@@ -2,17 +2,18 @@ package dnsimple
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/dnsimple/dnsimple-go/dnsimple"
+	"github.com/hashicorp/terraform-plugin-sdk/httpclient"
 	"golang.org/x/oauth2"
 )
 
 type Config struct {
-	Email            string
-	Account          string
-	Token            string
+	Email   string
+	Account string
+	Token   string
+
 	terraformVersion string
 }
 
@@ -23,13 +24,13 @@ type Client struct {
 	config *Config
 }
 
-// Client returns a new client for accessing dnsimple.
+// Client returns a new client for accessing DNSimple.
 func (c *Config) Client() (*Client, error) {
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: c.Token})
 	tc := oauth2.NewClient(context.Background(), ts)
 
 	client := dnsimple.NewClient(tc)
-	client.UserAgent = fmt.Sprintf("HashiCorp-Terraform/%s", c.terraformVersion)
+	client.UserAgent = httpclient.TerraformUserAgent(c.terraformVersion)
 
 	provider := &Client{
 		client: client,

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-dnsimple
 
 require (
 	cloud.google.com/go/pubsub v1.2.0 // indirect
-	github.com/dnsimple/dnsimple-go v0.30.0
+	github.com/dnsimple/dnsimple-go v0.31.0
 	github.com/golang/mock v1.4.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.1.0
 	github.com/kr/pretty v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnsimple/dnsimple-go v0.30.0/go.mod h1:O5TJ0/U6r7AfT8niYNlmohpLbCSG+c71tQlGr9SeGrg=
+github.com/dnsimple/dnsimple-go v0.31.0 h1:I1T+AxBQfhovyyfGSJ4CSUeH0iQejLArsUlhSQKw8WI=
+github.com/dnsimple/dnsimple-go v0.31.0/go.mod h1:O5TJ0/U6r7AfT8niYNlmohpLbCSG+c71tQlGr9SeGrg=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/vendor/github.com/dnsimple/dnsimple-go/LICENSE.txt
+++ b/vendor/github.com/dnsimple/dnsimple-go/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2018 Aetrion LLC dba DNSimple
+Copyright (c) 2014-2020 DNSimple Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/vendor/github.com/dnsimple/dnsimple-go/dnsimple/dnsimple.go
+++ b/vendor/github.com/dnsimple/dnsimple-go/dnsimple/dnsimple.go
@@ -23,7 +23,7 @@ const (
 	// This is a pro-forma convention given that Go dependencies
 	// tends to be fetched directly from the repo.
 	// It is also used in the user-agent identify the client.
-	Version = "0.30.0"
+	Version = "0.31.0"
 
 	// defaultBaseURL to the DNSimple production API.
 	defaultBaseURL = "https://api.dnsimple.com"
@@ -146,7 +146,7 @@ func formatUserAgent(customUserAgent string) string {
 		return defaultUserAgent
 	}
 
-	return fmt.Sprintf("%s %s", defaultUserAgent, customUserAgent)
+	return fmt.Sprintf("%s %s", customUserAgent, defaultUserAgent)
 }
 
 func versioned(path string) string {

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/httpclient/useragent.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/httpclient/useragent.go
@@ -1,0 +1,26 @@
+package httpclient
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/meta"
+)
+
+const uaEnvVar = "TF_APPEND_USER_AGENT"
+
+func TerraformUserAgent(version string) string {
+	ua := fmt.Sprintf("HashiCorp Terraform/%s (+https://www.terraform.io) Terraform Plugin SDK/%s", version, meta.SDKVersionString())
+
+	if add := os.Getenv(uaEnvVar); add != "" {
+		add = strings.TrimSpace(add)
+		if len(add) > 0 {
+			ua += " " + add
+			log.Printf("[DEBUG] Using modified User-Agent: %s", ua)
+		}
+	}
+
+	return ua
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/meta/meta.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/meta/meta.go
@@ -1,0 +1,36 @@
+// The meta package provides a location to set the release version
+// and any other relevant metadata for the SDK.
+//
+// This package should not import any other SDK packages.
+package meta
+
+import (
+	"fmt"
+
+	version "github.com/hashicorp/go-version"
+)
+
+// The main version number that is being run at the moment.
+var SDKVersion = "1.0.0"
+
+// A pre-release marker for the version. If this is "" (empty string)
+// then it means that it is a final release. Otherwise, this is a pre-release
+// such as "dev" (in development), "beta", "rc1", etc.
+var SDKPrerelease = ""
+
+// SemVer is an instance of version.Version. This has the secondary
+// benefit of verifying during tests and init time that our version is a
+// proper semantic version, which should always be the case.
+var SemVer *version.Version
+
+func init() {
+	SemVer = version.Must(version.NewVersion(SDKVersion))
+}
+
+// VersionString returns the complete version string, including prerelease
+func SDKVersionString() string {
+	if SDKPrerelease != "" {
+		return fmt.Sprintf("%s-%s", SDKVersion, SDKPrerelease)
+	}
+	return SDKVersion
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,6 +140,7 @@ github.com/hashicorp/terraform-config-inspect/tfconfig
 # github.com/hashicorp/terraform-plugin-sdk v1.1.0
 github.com/hashicorp/terraform-plugin-sdk/plugin
 github.com/hashicorp/terraform-plugin-sdk/helper/schema
+github.com/hashicorp/terraform-plugin-sdk/httpclient
 github.com/hashicorp/terraform-plugin-sdk/terraform
 github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema
 github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin
@@ -151,6 +152,7 @@ github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5
 github.com/hashicorp/terraform-plugin-sdk/helper/hashcode
 github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim
 github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags
+github.com/hashicorp/terraform-plugin-sdk/meta
 github.com/hashicorp/terraform-plugin-sdk/internal/addrs
 github.com/hashicorp/terraform-plugin-sdk/internal/configs
 github.com/hashicorp/terraform-plugin-sdk/internal/dag
@@ -273,16 +275,16 @@ golang.org/x/lint
 # golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 golang.org/x/net/context
 golang.org/x/net/trace
+golang.org/x/net/context/ctxhttp
 golang.org/x/net/internal/timeseries
 golang.org/x/net/http2
 golang.org/x/net/http2/hpack
 golang.org/x/net/idna
 golang.org/x/net/http/httpguts
-golang.org/x/net/context/ctxhttp
 # golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 golang.org/x/oauth2
-golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
+golang.org/x/oauth2/google
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
@@ -323,19 +325,19 @@ google.golang.org/api/internal/gensupport
 google.golang.org/api/googleapi/transport
 google.golang.org/api/transport/http/internal/propagation
 # google.golang.org/appengine v1.6.5
+google.golang.org/appengine/urlfetch
 google.golang.org/appengine/datastore
+google.golang.org/appengine/internal
+google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine
 google.golang.org/appengine/datastore/internal/cloudkey
-google.golang.org/appengine/internal
 google.golang.org/appengine/internal/datastore
-google.golang.org/appengine/urlfetch
-google.golang.org/appengine/internal/app_identity
-google.golang.org/appengine/internal/modules
-google.golang.org/appengine/datastore/internal/cloudpb
 google.golang.org/appengine/internal/base
 google.golang.org/appengine/internal/log
 google.golang.org/appengine/internal/remote_api
-google.golang.org/appengine/internal/urlfetch
+google.golang.org/appengine/internal/app_identity
+google.golang.org/appengine/internal/modules
+google.golang.org/appengine/datastore/internal/cloudpb
 # google.golang.org/genproto v0.0.0-20200207204624-4f3edf09f4f6
 google.golang.org/genproto/googleapis/rpc/status
 google.golang.org/genproto/googleapis/iam/v1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,7 +60,7 @@ github.com/bgentry/go-netrc/netrc
 github.com/bgentry/speakeasy
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/dnsimple/dnsimple-go v0.30.0
+# github.com/dnsimple/dnsimple-go v0.31.0
 github.com/dnsimple/dnsimple-go/dnsimple
 # github.com/fatih/color v1.7.0
 github.com/fatih/color


### PR DESCRIPTION
This PR is standardizing the user agent as recommended, by using `httpclient.TerraformUserAgent`.