### PR TITLE
Add `dnsimple_email_forward` resource

### DIFF
--- a/dnsimple/import_dnsimple_email_forward_test.go
+++ b/dnsimple/import_dnsimple_email_forward_test.go
@@ -1,0 +1,40 @@
+package dnsimple
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDnsimpleEmailForward_import(t *testing.T) {
+	resourceName := "dnsimple_email_forward.wildcard"
+	domain := os.Getenv("DNSIMPLE_DOMAIN")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSimpleEmailForwardDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDNSimpleEmailForwardConfig_import, domain),
+			},
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: fmt.Sprintf("%s_", domain),
+			},
+		},
+	})
+}
+
+const testAccCheckDNSimpleEmailForwardConfig_import = `
+resource "dnsimple_email_forward" "wildcard" {
+	domain = "%s"
+
+	from = "(.*)"
+	to   = "contacts@example.org"
+}
+`

--- a/dnsimple/provider.go
+++ b/dnsimple/provider.go
@@ -25,7 +25,8 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"dnsimple_record": resourceDNSimpleRecord(),
+			"dnsimple_email_forward": resourceDNSimpleEmailForward(),
+			"dnsimple_record":        resourceDNSimpleRecord(),
 		},
 	}
 	p.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {

--- a/dnsimple/resource_dnsimple_email_forward.go
+++ b/dnsimple/resource_dnsimple_email_forward.go
@@ -17,6 +17,9 @@ func resourceDNSimpleEmailForward() *schema.Resource {
 		Read:   resourceDNSimpleEmailForwardRead,
 		Update: resourceDNSimpleEmailForwardUpdate,
 		Delete: resourceDNSimpleEmailForwardDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceDNSimpleEmailForwardImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"domain": {
@@ -120,4 +123,20 @@ func resourceDNSimpleEmailForwardDelete(d *schema.ResourceData, meta interface{}
 	}
 
 	return nil
+}
+
+func resourceDNSimpleEmailForwardImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "_")
+
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Error Importing dnsimple_email_forward. Please make sure the email forward ID is in the form DOMAIN_FORWARDID (i.e. example.com_1234)")
+	}
+
+	d.SetId(parts[1])
+	d.Set("domain", parts[0])
+
+	if err := resourceDNSimpleEmailForwardRead(d, meta); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
 }

--- a/dnsimple/resource_dnsimple_email_forward.go
+++ b/dnsimple/resource_dnsimple_email_forward.go
@@ -1,0 +1,123 @@
+package dnsimple
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/dnsimple/dnsimple-go/dnsimple"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceDNSimpleEmailForward() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDNSimpleEmailForwardCreate,
+		Read:   resourceDNSimpleEmailForwardRead,
+		Update: resourceDNSimpleEmailForwardUpdate,
+		Delete: resourceDNSimpleEmailForwardDelete,
+
+		Schema: map[string]*schema.Schema{
+			"domain": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"from": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"to": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceDNSimpleEmailForwardCreate(d *schema.ResourceData, meta interface{}) error {
+	provider := meta.(*Client)
+
+	emailForwardAttributes := dnsimple.EmailForward{
+		From: d.Get("from").(string),
+		To:   d.Get("to").(string),
+	}
+
+	log.Printf("[DEBUG] DNSimple Email Forward create forwardAttributes: %#v", emailForwardAttributes)
+
+	resp, err := provider.client.Domains.CreateEmailForward(context.Background(), provider.config.Account, d.Get("domain").(string), emailForwardAttributes)
+	if err != nil {
+		return fmt.Errorf("Failed to create DNSimple EmailForward: %s", err)
+	}
+
+	d.SetId(strconv.FormatInt(resp.Data.ID, 10))
+	log.Printf("[INFO] DNSimple EmailForward ID: %s", d.Id())
+
+	return resourceDNSimpleEmailForwardRead(d, meta)
+}
+
+func resourceDNSimpleEmailForwardRead(d *schema.ResourceData, meta interface{}) error {
+	provider := meta.(*Client)
+
+	emailForwardID, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return fmt.Errorf("Error converting Email Forward ID: %s", err)
+	}
+
+	resp, err := provider.client.Domains.GetEmailForward(context.Background(), provider.config.Account, d.Get("domain").(string), emailForwardID)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			log.Printf("DNSimple Email Forward Not Found - Refreshing from State")
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Couldn't find DNSimple Email Forward: %s", err)
+	}
+
+	emailForward := resp.Data
+	/* The DNSimple API returns `from@domain` as the From address response, so
+	 * we must split on @ to get a blank `plan` following an `apply`.
+	 * If we put the full from@domain in the Terraform code for an email
+	 * forward, it ends up in DNSimple as `from@domain@domain`. */
+	fromParts := strings.Split(emailForward.From, "@")
+	d.Set("from", fromParts[0])
+	d.Set("to", emailForward.To)
+
+	return nil
+}
+
+func resourceDNSimpleEmailForwardUpdate(d *schema.ResourceData, meta interface{}) error {
+	provider := meta.(*Client)
+
+	emailForwardID, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return fmt.Errorf("Error converting EmailForward ID: %s", err)
+	}
+
+	_, err = provider.client.Domains.GetEmailForward(context.Background(), provider.config.Account, d.Get("domain").(string), emailForwardID)
+	if err != nil {
+		return fmt.Errorf("Failed to update DNSimple EmailForward: %s", err)
+	}
+
+	return resourceDNSimpleEmailForwardRead(d, meta)
+}
+
+func resourceDNSimpleEmailForwardDelete(d *schema.ResourceData, meta interface{}) error {
+	provider := meta.(*Client)
+
+	log.Printf("[INFO] Deleting DNSimple EmailForward: %s, %s", d.Get("domain").(string), d.Id())
+
+	emailForwardID, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return fmt.Errorf("Error converting EmailForward ID: %s", err)
+	}
+
+	_, err = provider.client.Domains.DeleteEmailForward(context.Background(), provider.config.Account, d.Get("domain").(string), emailForwardID)
+	if err != nil {
+		return fmt.Errorf("Error deleting DNSimple EmailForward: %s", err)
+	}
+
+	return nil
+}

--- a/dnsimple/resource_dnsimple_email_forward_test.go
+++ b/dnsimple/resource_dnsimple_email_forward_test.go
@@ -1,0 +1,134 @@
+package dnsimple
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/dnsimple/dnsimple-go/dnsimple"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccCheckDNSimpleEmailForwardConfig_Basic(t *testing.T) {
+	var emailForward dnsimple.EmailForward
+	domain := os.Getenv("DNSIMPLE_DOMAIN")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSimpleEmailForwardDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDNSimpleEmailForwardConfig_basic, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSimpleEmailForwardExists("dnsimple_email_forward.hello", &emailForward),
+					testAccCheckDNSimpleEmailForwardAttributes(&emailForward),
+					resource.TestCheckResourceAttr(
+						"dnsimple_email_forward.hello", "domain", domain),
+					// We can't check "from" value here because the API returns `addr@domain` not just `addr`.
+					resource.TestCheckResourceAttr(
+						"dnsimple_email_forward.hello", "to", "hi@example.org"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDNSimpleEmailForwardDestroy(s *terraform.State) error {
+	provider := testAccProvider.Meta().(*Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "dnsimple_email_forward" {
+			continue
+		}
+
+		emailForwardID, _ := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		_, err := provider.client.Domains.GetEmailForward(context.Background(), provider.config.Account, rs.Primary.Attributes["domain"], emailForwardID)
+		if err == nil {
+			return fmt.Errorf("EmailForward still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckDNSimpleEmailForwardAttributes(emailForward *dnsimple.EmailForward) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if emailForward.To != "hi@example.org" {
+			return fmt.Errorf("Bad content: %s", emailForward.To)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDNSimpleEmailForwardAttributesUpdated(emailForward *dnsimple.EmailForward) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if emailForward.To != "contacts@example.org" {
+			return fmt.Errorf("Bad content: %s", emailForward.To)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDNSimpleEmailForwardExists(n string, emailForward *dnsimple.EmailForward) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Email Forward ID is set")
+		}
+
+		provider := testAccProvider.Meta().(*Client)
+
+		emailForwardID, _ := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		resp, err := provider.client.Domains.GetEmailForward(context.Background(), provider.config.Account, rs.Primary.Attributes["domain"], emailForwardID)
+		if err != nil {
+			return err
+		}
+
+		foundEmailForward := resp.Data
+		if foundEmailForward.ID != emailForwardID {
+			return fmt.Errorf("EmailForward not found")
+		}
+
+		*emailForward = *foundEmailForward
+
+		return nil
+	}
+}
+
+const testAccCheckDNSimpleEmailForwardConfig_basic = `
+resource "dnsimple_email_forward" "hello" {
+	domain = "%s"
+
+	from = "hello"
+	to   = "hi@example.org"
+}`
+
+const testAccCheckDNSimpleEmailForwardConfig_new_value = `
+resource "dnsimple_email_forward" "hello" {
+	domain = "%s"
+
+	from = "hello"
+	to   = "contacts@example.org"
+}`
+
+const testAccCheckDNSimpleEmailForwardConfig_wildcard = `
+resource "dnsimple_email_forward" "wildcard" {
+	domain = "%s"
+
+	from = "(.*)"
+	to = "contacts@example.org"
+}
+`

--- a/dnsimple/resource_dnsimple_email_forward_test.go
+++ b/dnsimple/resource_dnsimple_email_forward_test.go
@@ -123,12 +123,3 @@ resource "dnsimple_email_forward" "hello" {
 	from = "hello"
 	to   = "contacts@example.org"
 }`
-
-const testAccCheckDNSimpleEmailForwardConfig_wildcard = `
-resource "dnsimple_email_forward" "wildcard" {
-	domain = "%s"
-
-	from = "(.*)"
-	to = "contacts@example.org"
-}
-`

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -27,6 +27,11 @@ provider "dnsimple" {
 resource "dnsimple_record" "www" {
   # ...
 }
+
+# Create an email forward
+resource "dnsimple_email_forward" "hello" {
+  # ...
+}
 ```
 
 

--- a/website/docs/r/email_forward.html.markdown
+++ b/website/docs/r/email_forward.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "dnsimple"
+page_title: "DNSimple: dnsimple_email_forward"
+sidebar_current: "docs-dnsimple-resource-email-forward"
+description: |-
+  Provides a DNSimple email forward resource.
+---
+
+# dnsimple\_email\_forward
+
+Provides a DNSimple email forward resource.
+
+## Example Usage
+
+```hcl
+# Add an email forwarding rule to the domain
+resource "dnsimple_email_forward" "foobar" {
+  domain = "${var.dnsimple_domain}"
+  from   = "sales"
+  to     = "jane.doe@example.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain` - (Required) The domain to add the email forwarding rule to
+* `from` - (Required) The source email address on the domain
+* `to` - (Required) The destination email address on another domain
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The email forward ID
+* `from` - The source email address on the domain
+* `to` - The destination email address on another domain


### PR DESCRIPTION
- First of all, thanks for building this provider! 😍
- While I was setting a bunch of DNSimple records up with Terraform, I thought it would be nice to be able to configure DNSimple email forwarding for domains in the same way.
- This implements CRUD and importing of DNSimple Email Forwarding rules.
- The following example Terraform config documents the new resource:

```hcl
resource "dnsimple_email_forward" "test" {
  domain    = "issyl0.dev"
  from      = "tf"
  to        = "me@issyl0.co.uk"
}
```

----

This is draft for two reasons (hopefully that's OK):

- ~The tests don't pass, and the `plan` post-`apply` doesn't come out with "no changes". This is because the DNSimple API seems to accept only the first part of a `from` address as input, but returns the whole thing as the response. I don't know if that's intentional. I could probably work around it with some splitting on `@`? If I try "tf@issyl0.dev" as `from`, the created email forward ends up as "tf@issyl0.dev@issyl0.dev". I'd appreciate maintainers' opinions on approaches here!~
- ~Importing this resource doesn't work yet (I get the same error as in #27). This would be very useful for me and I suspect others, but I can't figure it out right now.~